### PR TITLE
remove invocation of unknown method _check_login

### DIFF
--- a/XTBApi/api.py
+++ b/XTBApi/api.py
@@ -192,7 +192,6 @@ class BaseClient(object):
         """getChartRangeRequest command"""
         if not isinstance(ticks, int):
             raise ValueError(f"ticks value {ticks} must be int")
-        self._check_login()
         args = {
             "end": end * 1000,
             "period": period,


### PR DESCRIPTION
Greetings,

Looks like invocation to _check_login is causing the following error:

**self._check_login()\nAttributeError: \'Client\' object has no attribute \'_check_login\'\n')**

when calling **get_chart_range_request**.

I prepared temporary fix which works for me.

I hope it will be useful.

Best Regards,
Flowersky